### PR TITLE
feat: Add OpenVPN support

### DIFF
--- a/backends/sh/openvpn_connect.sh
+++ b/backends/sh/openvpn_connect.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# ==============================================================================
+# Holocron OpenVPN Connector
+#
+# Description:
+# This script starts or stops an OpenVPN connection using a provided
+# configuration file. It manages the process using a PID lock file.
+# It's designed to be called by the Holocron native host script.
+#
+# Requirements:
+# - openvpn: The OpenVPN client binary.
+# - sudo: The script requires sudo to manage network interfaces and run openvpn.
+#   Passwordless sudo may be required for the user running the browser.
+# ==============================================================================
+
+# --- Configuration ---
+# The lock file path should be in a location writable by the user.
+# Using a directory inside $HOME/.config/ is a good practice.
+CONFIG_DIR="$HOME/.config/holocron"
+mkdir -p "$CONFIG_DIR" # Ensure the directory exists
+LOCK_FILE="$CONFIG_DIR/openvpn.lock"
+LOG_FILE="/tmp/holocron_openvpn_output.log"
+
+# --- Full paths for reliability ---
+# Common path on Linux. For macOS (e.g., via Homebrew), it might be /usr/local/sbin/openvpn
+OPENVPN_PATH="/usr/sbin/openvpn"
+SUDO_PATH="/usr/bin/sudo"
+
+start_vpn() {
+    # --- Pre-flight Checks ---
+    if [ -f "$LOCK_FILE" ]; then
+        PID=$(cat "$LOCK_FILE")
+        if [ -n "$PID" ] && ps -p "$PID" > /dev/null; then
+            echo "✅ OpenVPN is already running with PID $PID."
+            return 3 # Special exit code for "already running"
+        else
+            echo "⚠️ Found stale lock file. Removing it."
+            rm -f "$LOCK_FILE"
+        fi
+    fi
+
+    # --- Argument Parsing ---
+    local config_file=""
+    local auth_file=""
+
+    while (( "$#" )); do
+      case "$1" in
+        --config)
+          config_file="$2"
+          shift 2
+          ;;
+        --auth-file)
+          auth_file="$2"
+          shift 2
+          ;;
+        *)
+          echo "Unknown argument: $1" >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    if [ -z "$config_file" ]; then
+        echo "❌ Error: --config file path is required." >&2
+        return 1
+    fi
+
+    # --- Start Tunnel ---
+    echo "🚀 Starting OpenVPN tunnel..."
+    local openvpn_args=(
+        "--config" "$config_file"
+        "--daemon" # Run in the background
+        "--log" "$LOG_FILE" # Log to a file
+        # Note: --writepid is executed by openvpn with root privileges, so it can write anywhere.
+        # But for consistency, we're using a file we know we can manage.
+        "--writepid" "$LOCK_FILE"
+    )
+
+    if [ -n "$auth_file" ]; then
+        openvpn_args+=("--auth-user-pass" "$auth_file")
+    fi
+
+    # Check if openvpn binary exists
+    if [ ! -f "$OPENVPN_PATH" ]; then
+        # Fallback for Homebrew on macOS
+        if [ -f "/usr/local/sbin/openvpn" ]; then
+            OPENVPN_PATH="/usr/local/sbin/openvpn"
+        else
+            echo "❌ Error: OpenVPN binary not found at $OPENVPN_PATH or /usr/local/sbin/openvpn" >&2
+            return 1
+        fi
+    fi
+
+    "$SUDO_PATH" "$OPENVPN_PATH" "${openvpn_args[@]}"
+
+    # Wait a moment for the PID file to be created by the daemon
+    sleep 2
+
+    if [ ! -f "$LOCK_FILE" ] || [ -z "$(cat "$LOCK_FILE")" ]; then
+        echo "❌ Error: OpenVPN failed to start. Check the log for details:" >&2
+        echo "   $LOG_FILE" >&2
+        rm -f "$LOCK_FILE" # Clean up empty lock file
+        return 1
+    fi
+
+    VPN_PID=$(cat "$LOCK_FILE")
+    if ps -p "$VPN_PID" > /dev/null; then
+        echo "✅ OpenVPN started successfully with PID $VPN_PID."
+        return 0
+    else
+        echo "❌ Error: OpenVPN process with PID $VPN_PID exited unexpectedly." >&2
+        echo "   Check the log for details: $LOG_FILE" >&2
+        rm -f "$LOCK_FILE"
+        return 1
+    fi
+}
+
+stop_vpn() {
+    if [ ! -f "$LOCK_FILE" ]; then
+        echo "ℹ️ OpenVPN appears to be stopped already."
+        return 0
+    fi
+
+    PID_TO_KILL=$(cat "$LOCK_FILE")
+    if [ -z "$PID_TO_KILL" ]; then
+        echo "⚠️ Lock file is empty. Removing it."
+        rm -f "$LOCK_FILE"
+        return 1
+    fi
+
+    if ps -p "$PID_TO_KILL" > /dev/null; then
+        echo "🛑 Stopping OpenVPN process with PID $PID_TO_KILL..."
+        "$SUDO_PATH" kill "$PID_TO_KILL"
+        # Wait a moment for the process to terminate
+        sleep 2
+    else
+        echo "⚠️ PID $PID_TO_KILL from lock file is not a running process."
+    fi
+
+    # Clean up lock file regardless
+    rm -f "$LOCK_FILE"
+    echo "✅ OpenVPN stopped."
+}
+
+
+# --- Main Logic ---
+case "$1" in
+    start) start_vpn "${@:2}" ;;
+    stop) stop_vpn ;;
+    *)
+      echo "Usage: $0 {start|stop}"
+      exit 1
+      ;;
+esac

--- a/constants.js
+++ b/constants.js
@@ -2,16 +2,28 @@
 // to prevent typos and make maintenance easier.
 
 const STORAGE_KEYS = {
-  // --- Settings ---
+  // --- General Settings ---
+  CONNECTION_TYPE: 'connectionType', // 'ssh' or 'openvpn'
+
+  // --- SSH Settings ---
   SSH_COMMAND_ID: 'sshCommandIdentifier',
   SSH_USER: 'sshUser',
   SSH_HOST: 'sshHost',
+  PORT_FORWARDS: 'portForwards',
+  WIFI_SSIDS: 'wifiSsidList',
+
+  // --- OpenVPN Settings ---
+  OVPN_CONFIGS: 'ovpnConfigs', // Stores { name, content, requires_auth }
+  ACTIVE_OVPN_CONFIG_NAME: 'activeOvpnConfigName',
+  OVPN_USER: 'ovpnUser',
+  OVPN_PASS: 'ovpnPass',
+
+  // --- Shared Settings ---
   PING_HOST: 'pingHost',
   WEB_CHECK_URL: 'webCheckUrl',
-  PORT_FORWARDS: 'portForwards',
-  WIFI_SSIDS: 'wifiSsidList', // New key for Wi-Fi networks
   GEOIP_BYPASS_ENABLED: 'geoIpBypassEnabled',
   AUTO_RECONNECT_ENABLED: 'autoReconnectEnabled',
+
 
   // --- State ---
   IS_PROXY_MANAGED: 'isProxyManagedByHolocron',
@@ -19,12 +31,15 @@ const STORAGE_KEYS = {
 };
 
 const COMMANDS = {
+  // --- General Commands ---
   GET_STATUS: 'getStatus',
   STATUS_UPDATED: 'statusUpdated',
   GET_POPUP_STATUS: 'getPopupStatus',
   SET_BROWSER_PROXY: 'setBrowserProxy',
   CLEAR_BROWSER_PROXY: 'clearBrowserProxy',
   TEST_CONNECTION: 'testConnection',
-  START_TUNNEL: 'startTunnel',
-  STOP_TUNNEL: 'stopTunnel',
+
+  // --- Tunnel Commands ---
+  START_TUNNEL: 'startTunnel', // This will become a generic 'start'
+  STOP_TUNNEL: 'stopTunnel',   // This will become a generic 'stop'
 };

--- a/options.html
+++ b/options.html
@@ -9,65 +9,110 @@
     <h1>Holocron Settings</h1>
 
     <div class="form-section">
-      <h2>Connection Monitoring</h2>
-      <div class="form-group">
-        <label for="ssh-command">SSH Process Identifier</label>
-        <input type="text" id="ssh-command" placeholder="e.g., holocron-tunnel">
-        <small>A unique string used to identify the tunnel process. The script uses this to create a unique tag for the SSH command.</small>
-      </div>
-      <div class="form-group">
-        <label for="ping-host">TCP Ping Host</label>
-        <input type="text" id="ping-host" placeholder="e.g., youtube.com">
-        <small>A reliable host for a low-level TCP connection check.</small>
-      </div>
-      <div class="form-group">
-        <label for="web-check-url">Web Check URL</label>
-        <input type="text" id="web-check-url" placeholder="e.g., https://gemini.google.com/app">
-        <small>A full URL to check for application-level connectivity through the tunnel.</small>
+      <h2>Connection Type</h2>
+      <div class="radio-group">
+        <input type="radio" id="conn-type-ssh" name="connection-type" value="ssh" checked>
+        <label for="conn-type-ssh">SSH Tunnel</label>
+        <input type="radio" id="conn-type-ovpn" name="connection-type" value="openvpn">
+        <label for="conn-type-ovpn">OpenVPN</label>
       </div>
     </div>
 
-    <div class="form-section">
-      <h2>Automatic Connection Networks (Optional)</h2>
-      <small>The tunnel will only auto-connect on these Wi-Fi networks. Leave this section empty to disable the check and allow manual connection from any network.</small>
-      <fieldset class="wifi-networks-section">
-        <legend>Permitted SSIDs</legend>
-        <div id="wifi-networks-list">
-          <!-- SSIDs will be dynamically inserted here -->
+    <!-- ===== SSH Settings ===== -->
+    <div id="ssh-settings-section">
+      <div class="form-section">
+        <h2>Connection Monitoring</h2>
+        <div class="form-group">
+          <label for="ssh-command">SSH Process Identifier</label>
+          <input type="text" id="ssh-command" placeholder="e.g., holocron-tunnel">
+          <small>A unique string used to identify the tunnel process. The script uses this to create a unique tag for the SSH command.</small>
         </div>
-        <button id="add-wifi-button" class="button-secondary">Add Wi-Fi Network</button>
-      </fieldset>
+        <div class="form-group">
+          <label for="ping-host">TCP Ping Host</label>
+          <input type="text" id="ping-host" placeholder="e.g., youtube.com">
+          <small>A reliable host for a low-level TCP connection check.</small>
+        </div>
+        <div class="form-group">
+          <label for="web-check-url">Web Check URL</label>
+          <input type="text" id="web-check-url" placeholder="e.g., https://gemini.google.com/app">
+          <small>A full URL to check for application-level connectivity through the tunnel.</small>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h2>Automatic Connection Networks (Optional)</h2>
+        <small>The tunnel will only auto-connect on these Wi-Fi networks. Leave this section empty to disable the check and allow manual connection from any network.</small>
+        <fieldset class="wifi-networks-section">
+          <legend>Permitted SSIDs</legend>
+          <div id="wifi-networks-list">
+            <!-- SSIDs will be dynamically inserted here -->
+          </div>
+          <button id="add-wifi-button" class="button-secondary">Add Wi-Fi Network</button>
+        </fieldset>
+      </div>
+
+      <div class="form-section">
+        <h2>SSH Tunnel Configuration</h2>
+        <div class="form-group">
+          <label for="ssh-user">SSH User</label>
+          <input type="text" id="ssh-user" placeholder="e.g., ubuntu">
+        </div>
+        <div class="form-group">
+          <label for="ssh-host">SSH Host (Bastion)</label>
+          <input type="text" id="ssh-host" placeholder="e.g., bastion.example.com">
+        </div>
+        <fieldset class="port-forwarding-section">
+          <legend>Port Forwarding Rules</legend>
+          <div id="port-forwarding-rules">
+            <!-- Rules will be dynamically inserted here -->
+          </div>
+          <button id="add-rule-button" class="button-secondary">Add Rule</button>
+        </fieldset>
+      </div>
     </div>
 
+    <!-- ===== OpenVPN Settings ===== -->
+    <div id="openvpn-settings-section" style="display: none;">
+      <div class="form-section">
+        <h2>OpenVPN Configuration</h2>
+        <fieldset>
+          <legend>VPN Profiles</legend>
+          <div id="ovpn-configs-list">
+            <!-- OpenVPN configs will be dynamically inserted here -->
+          </div>
+          <div class="form-group">
+            <label for="ovpn-file-upload">Upload .ovpn Profile</label>
+            <input type="file" id="ovpn-file-upload" accept=".ovpn">
+          </div>
+        </fieldset>
+      </div>
+      <div class="form-section">
+        <h2>OpenVPN Credentials (if required)</h2>
+        <small>These are only needed if your .ovpn profile uses the <code>auth-user-pass</code> directive without an external file path.</small>
+        <div class="form-group">
+          <label for="ovpn-user">Username</label>
+          <input type="text" id="ovpn-user" placeholder="VPN Username">
+        </div>
+        <div class="form-group">
+          <label for="ovpn-pass">Password</label>
+          <input type="password" id="ovpn-pass" placeholder="VPN Password">
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Shared Settings ===== -->
     <div class="form-section">
-      <h2>SSH Tunnel Configuration</h2>
-      <div class="form-group">
-        <label for="ssh-user">SSH User</label>
-        <input type="text" id="ssh-user" placeholder="e.g., ubuntu">
-      </div>
-      <div class="form-group">
-        <label for="ssh-host">SSH Host (Bastion)</label>
-        <input type="text" id="ssh-host" placeholder="e.g., bastion.example.com">
-      </div>
-
-      <div class="form-group">
-        <label for="auto-reconnect-enabled">Automatic Reconnect</label>
-        <div class="checkbox-container">
-            <input type="checkbox" id="auto-reconnect-enabled">
-            <label for="auto-reconnect-enabled" class="checkbox-label">
-                Automatically attempt to reconnect the tunnel if it disconnects.
-            </label>
+        <h2>General Settings</h2>
+        <div class="form-group">
+            <label for="auto-reconnect-enabled">Automatic Reconnect</label>
+            <div class="checkbox-container">
+                <input type="checkbox" id="auto-reconnect-enabled">
+                <label for="auto-reconnect-enabled" class="checkbox-label">
+                    Automatically attempt to reconnect the tunnel if it disconnects.
+                </label>
+            </div>
+            <small>If the tunnel process stops unexpectedly, the extension will try to restart it. This respects any Wi-Fi network rules for SSH.</small>
         </div>
-        <small>If the tunnel process stops unexpectedly, the extension will try to restart it. This respects the Wi-Fi network rules.</small>
-      </div>
-
-      <fieldset class="port-forwarding-section">
-        <legend>Port Forwarding Rules</legend>
-        <div id="port-forwarding-rules">
-          <!-- Rules will be dynamically inserted here -->
-        </div>
-        <button id="add-rule-button" class="button-secondary">Add Rule</button>
-      </fieldset>
     </div>
 
     <div class="form-section">
@@ -90,6 +135,14 @@
     </div>
     <div id="status-message"></div>
   </div>
+
+  <template id="ovpn-config-template">
+    <div class="rule-item ovpn-item">
+      <input type="radio" name="active-ovpn-config">
+      <span class="ovpn-name"></span>
+      <button class="remove-rule-button" title="Remove Config">&times;</button>
+    </div>
+  </template>
 
   <template id="port-forward-rule-template">
     <div class="rule-item">


### PR DESCRIPTION
This commit introduces support for OpenVPN connections, allowing users to upload and manage `.ovpn` profiles.

The implementation includes:
- A new UI in the options page to switch between SSH and OpenVPN connection types.
- Functionality to upload, store, and select `.ovpn` configuration files.
- A new backend shell script (`openvpn_connect.sh`) to manage the OpenVPN process lifecycle.
- Enhancements to the Python native host to handle OpenVPN-specific commands, including starting, stopping, and checking the status of the connection.
- Refactoring of the communication protocol between the extension and the native host to be more extensible, passing a full configuration object.