### PR TITLE
feat: Implement incognito proxy, predefined profiles, and WebRTC toggle

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -12,6 +12,8 @@ export const STORAGE_KEYS = {
   PROXY_BYPASS_RULES: 'proxyBypassRules',
   GLOBAL_GEOIP_BYPASS_ENABLED: 'globalGeoIpBypassEnabled',
   GLOBAL_GEOSITE_BYPASS_ENABLED: 'globalGeoSiteBypassEnabled',
+  INCOGNITO_PROXY_CONFIG_ID: 'incognitoProxyConfigId',
+  WEBRTC_IP_HANDLING_POLICY: 'webRtcIpHandlingPolicy',
   OPENROUTER_API_KEY: 'openrouter_api_key',
   OPENROUTER_MODEL: 'openrouter_model',
   OPENROUTER_SYSTEM_MESSAGE: 'openrouter_system_message',
@@ -47,4 +49,5 @@ export const COMMANDS = {
   MANUAL_DB_UPDATE: 'manualDbUpdate',
   GET_LOGS: 'getLogs',
   CLEAR_LOGS: 'clearLogs',
+  APPLY_WEBRTC_POLICY: 'applyWebRtcPolicy',
 };

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "proxy",
     "alarms",
     "nativeMessaging",
-    "offscreen"
+    "offscreen",
+    "privacy"
   ],
   "host_permissions": [
     "https://cdn.jsdelivr.net/",

--- a/options.css
+++ b/options.css
@@ -495,3 +495,44 @@ input:checked + .slider:before { transform: translateX(20px); }
         filter: brightness(1.15);
     }
 }
+
+/* --- Modal Styles --- */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--container-bg);
+    padding: 2em;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    max-width: 500px;
+    width: 90%;
+}
+
+.predefined-choices {
+    display: flex;
+    gap: 1em;
+    flex-wrap: wrap;
+}
+
+.predefined-choices button {
+    background-color: var(--add-button-bg);
+    color: var(--add-button-text);
+    border: 1px solid transparent;
+    flex-grow: 1;
+}
+
+.predefined-choices button:hover {
+    background-color: var(--add-button-bg-hover);
+    border-color: var(--add-button-text);
+}

--- a/options.html
+++ b/options.html
@@ -66,7 +66,10 @@
                                 <div id="core-configurations-list">
                                     <!-- Configurations will be dynamically inserted here -->
                                 </div>
-                                <button id="add-config-button" class="add-button">+ Add Configuration</button>
+                                <div class="button-group" style="margin-top: 1em; display: flex; gap: 10px;">
+                                    <button id="add-config-button" class="add-button" style="margin-top: 0;">+ Add Custom Configuration</button>
+                                    <button id="add-predefined-config-button" class="add-button" style="margin-top: 0;">+ Add Predefined Profile</button>
+                                </div>
                             </section>
                              <section class="card">
                                 <details>
@@ -143,6 +146,16 @@
                                         <input type="checkbox" id="global-geosite-bypass">
                                         <label for="global-geosite-bypass">Bypass proxy for Iranian sites (GeoSite)</label>
                                     </div>
+                                    <h3 class="sub-heading" style="margin-top: 1.5em; padding-top: 1em; border-top: 1px solid var(--border-color-light);">Incognito Mode Proxy</h3>
+                                    <div class="form-group">
+                                        <label for="incognito-proxy-select">Incognito-Specific Proxy</label>
+                                        <select id="incognito-proxy-select" name="incognito-proxy-select">
+                                            <option value="">-- Use Regular Proxy Settings --</option>
+                                            <!-- Options will be populated by JS -->
+                                        </select>
+                                        <small>Select a configuration to use exclusively for Incognito windows. This will not affect your regular browsing session.</small>
+                                    </div>
+
                                     <h3 class="sub-heading" style="margin-top: 1.5em; padding-top: 1em; border-top: 1px solid var(--border-color-light);">Custom Routing Rules</h3>
                                     <div id="proxy-bypass-rules-list">
                                         <!-- Custom rules will be inserted here -->
@@ -184,6 +197,14 @@
                             </div>
                             <div id="ai-live-log-container" class="log-viewer-container" style="display: none; margin-top: 1em; height: 150px;">
                                 <pre id="ai-live-log-content"></pre>
+                            </div>
+                        </section>
+                        <section class="card">
+                            <h2>Privacy Controls</h2>
+                             <div class="form-group checkbox-group">
+                                <input type="checkbox" id="webrtc-policy-toggle" name="webrtc-policy-toggle">
+                                <label for="webrtc-policy-toggle">Prevent WebRTC IP Leak</label>
+                                <small>Sets WebRTC to only use proxied network connections, preventing your real IP from being exposed. Recommended to keep enabled.</small>
                             </div>
                         </section>
                         <section class="card">
@@ -290,7 +311,29 @@
                         <option value="ssh">SSH Tunnel</option>
                         <option value="openvpn">OpenVPN</option>
                         <option value="v2ray">V2Ray</option>
+                        <option value="external">External Proxy</option>
                     </select>
+                </div>
+
+                <!-- External Proxy Specific Fields -->
+                <div class="external-settings" style="display: none;">
+                    <div class="form-group">
+                        <label>Proxy Protocol</label>
+                        <select class="config-input-external-protocol">
+                            <option value="SOCKS5">SOCKS5</option>
+                            <option value="SOCKS4">SOCKS4</option>
+                            <option value="HTTP">HTTP</option>
+                            <option value="HTTPS">HTTPS</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Proxy Host</label>
+                        <input type="text" class="config-input-external-host" placeholder="127.0.0.1">
+                    </div>
+                    <div class="form-group">
+                        <label>Proxy Port</label>
+                        <input type="number" class="config-input-external-port" placeholder="9050" min="1" max="65535">
+                    </div>
                 </div>
 
                 <!-- SSH Specific Fields -->
@@ -358,6 +401,21 @@
 
     <script src="vendor/chart.js"></script>
     <script type="module" src="options.js"></script>
+
+    <!-- Modal for Predefined Profiles -->
+    <div id="predefined-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h2 style="margin-top:0;">Add a Predefined Profile</h2>
+            <p>Select a service to create a pre-configured "External Proxy" profile for it. You must ensure the service (e.g., the Tor client) is running on your computer for the proxy to work.</p>
+            <div class="predefined-choices">
+                <button data-profile="tor">Tor</button>
+                <button data-profile="privoxy">Privoxy</button>
+                <button data-profile="psiphon">Psiphon (SOCKS)</button>
+            </div>
+            <button id="modal-close-button" class="button-secondary" style="margin-top: 1.5em;">Cancel</button>
+        </div>
+    </div>
+
     <footer style="margin-top: 2em;">
         <section class="card full-width">
             <h2>Geo-Database Status</h2>


### PR DESCRIPTION
This commit introduces several major features to enhance the extension's privacy and usability.

1.  **Incognito-Specific Proxy:** Users can now select a specific proxy configuration to be used exclusively for Incognito mode. This is handled via a new dropdown on the options page and uses the 'incognito_persistent' scope of the `chrome.proxy` API.

2.  **Predefined Selections & External Proxy Type:** To support one-click configurations for services like Tor and Privoxy, a new "External Proxy" configuration type has been added. This allows the extension to route traffic through any manually specified proxy (SOCKS5, SOCKS4, HTTP, HTTPS), not just tunnels managed by the extension.

    A new "Add Predefined Profile" button uses this new type to create pre-filled configurations for Tor, Privoxy, and Psiphon.

3.  **WebRTC Toggle:** A new "Privacy Controls" section has been added with a toggle to prevent WebRTC IP leaks. This sets the `webRTCIPHandlingPolicy` to 'disable_non_proxied_udp'. The setting is applied on browser startup and whenever it's changed in the options.